### PR TITLE
New development dashboard using webpack-dashboard

### DIFF
--- a/commands/start/index.js
+++ b/commands/start/index.js
@@ -21,5 +21,5 @@ module.exports = (args, done) => {
   let server = new DevServer(compiler, config.devServer);
 
   process.on('SIGINT', done);
-  server.listen(port, host, () => console.log(`Listening on ${schema}://${host}:${port}`));
+  server.listen(port, host, () => console.log(`{green-fg}Dev server started on:{/} ${schema}://${host}:${port}`));
 };

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -2,10 +2,15 @@ const core = require('./webpack.core');
 const merge = require('webpack-merge');
 const path = require('path');
 const webpack = require('webpack');
+const Dashboard = require('webpack-dashboard');
+const DashboardPlugin = require('webpack-dashboard/plugin');
+
+const dashboard = new Dashboard();
 
 module.exports = merge(core, {
   devtool: 'hidden-source-map',
   plugins: [
+    new DashboardPlugin(dashboard.setData),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
       minChunks: Infinity,
@@ -20,15 +25,13 @@ module.exports = merge(core, {
   },
   devServer: {
     contentBase: path.join(process.cwd(), 'src'),
-
     // Enable history API fallback so HTML5 History API based
     // routing works. This is a good default that will come
     // in handy in more complicated setups.
     historyApiFallback: true,
-
     hot: true,
     progress: true,
-
+    quiet: true,
     // Display only errors to reduce the amount of output.
     stats: 'errors-only'
   }

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "url-loader": "0.5.7",
     "vorpal": "1.4.1",
     "webpack": "1.13.1",
+    "webpack-dashboard": "FormidableLabs/webpack-dashboard#redirect-console",
     "webpack-dev-server": "1.14.1",
     "webpack-hot-middleware": "2.12.2",
     "webpack-merge": "0.14.1",


### PR DESCRIPTION
Still need to wait to land this until webpack-dashboard supports [redirecting `console.log` to the dashboard](https://github.com/FormidableLabs/webpack-dashboard/pull/27).
