### PR TITLE
Add `src/` directory to webpack's resolve.root

### DIFF
--- a/config/webpack.core.js
+++ b/config/webpack.core.js
@@ -49,7 +49,7 @@ module.exports = {
     }, PACKAGE.config.html || {}))
   ],
   resolve: {
-    root: [NODE_MODULES, CWD_NODE_MODULES],
+    root: [SRC, NODE_MODULES, CWD_NODE_MODULES],
     extensions: ['', '.js', '.jsx', '.json']
   },
   resolveLoader: {


### PR DESCRIPTION
Adding the `src/` directory to resolve.root allows developers to import
modules without having to give the relative path to the current file
imoprting the module.  This makes it easier to refactor the code as it's
easier to reason about module paths relative to the project's root
folder.

This is also backwards compatible, and relative imports are still
possible.

Closes #66