### PR TITLE
Load tests from any directory in `tests/`

### DIFF
--- a/config/karma.js
+++ b/config/karma.js
@@ -2,7 +2,7 @@
 
 const testConfig = require('./webpack.test');
 
-const TESTS = 'tests/*_test.js';
+const TESTS = 'tests/**/*_test.js';
 
 module.exports = {
   basePath: process.cwd(),


### PR DESCRIPTION
This file pattern allows tests to be better organized inside the
`tests/` directory, picking up tests in any number of subdirectories.
This is particularly useful for larger projects.