### PR TITLE
Lint test files

### DIFF
--- a/config/eslint.core.js
+++ b/config/eslint.core.js
@@ -22,6 +22,7 @@ module.exports = {
     browser: true,
     commonjs: true,
     es6: true,
+    mocha: true,
     node: true
   },
   parser: 'babel-eslint',

--- a/config/webpack.core.js
+++ b/config/webpack.core.js
@@ -63,7 +63,7 @@ module.exports = {
     preLoaders: [
       {
         test: /\.jsx?$/,
-        include: [SRC],
+        include: [SRC, TESTS],
         loader: 'eslint'
       }
     ],


### PR DESCRIPTION
This adds the `tests/` directory to the list of files that need to be
linted. It also adds `mocha` to the linting evironment so that eslint
doesn't complain about things like `describe` or `it` not being defined.